### PR TITLE
NANGO-677: Allow the websockets path to be configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,12 @@ WORKER_PORT=3004
 #
 NANGO_SERVER_URL=http://localhost:3003
 #
+# - Configure server websockets path (current value is the default for running Nango locally).
+#   If this is changed from the default, the client must be configured to use the same path using the `websocketsPath` 
+#   config option in the Nango constructor.
+#
+# NANGO_SERVER_WEBSOCKETS_PATH=/
+#
 #
 # - Configure a custom callback URL (by default it is NANGO_SERVER_URL/oauth/callback).
 #

--- a/docs-v2/sdks/frontend.mdx
+++ b/docs-v2/sdks/frontend.mdx
@@ -42,6 +42,14 @@ import Nango from '@nangohq/frontend';
 let nango = new Nango({ host: 'https://<YOUR-NANGO-INSTANCE>' });
 ```
 
+If you have configured your self-hosted instance to use a [custom websockets path](/self-host/instructions#custom-websockets-path)
+you will also need to set the `websocketsPath` configuration option:
+
+```ts
+import Nango from '@nangohq/frontend';
+
+let nango = new Nango({ host: 'https://<YOUR-NANGO-INSTANCE>', websocketsPath: '/<YOUR-WEBSOCKETS-PATH>' });
+```
 </Tab>
 
 </Tabs>

--- a/docs-v2/self-host/instructions.mdx
+++ b/docs-v2/self-host/instructions.mdx
@@ -125,6 +125,25 @@ Once you restart the Nango server, the encryption of the database will happen
 automatically. Please note that, at the current time, you cannot modify this
 encryption key once you have set it.
 
+### Custom websockets path[](#custom-websockets-path 'Direct link to Custom websockets path')
+
+The Nango server serves websockets from the `/` path by default for use by `@nangohq/frontend` during the login flow. 
+If you want more isolation between websockets and the dashboard (also served from `/`) then you can set the 
+`NANGO_SERVER_WEBSOCKETS_PATH` environment variable to serve websockets from a different path:
+
+```
+NANGO_SERVER_WEBSOCKETS_PATH=</YOUR-WEBSOCKETS-PATH>
+```
+
+If you do set this variable to a different path, you will need to configure the `websocketsPath` parameter when 
+initializing the `Nango` object in the `@nangohq/frontend` SDK:
+
+```js
+import Nango from '@nangohq/frontend';
+
+let nango = new Nango({ host: 'https://<YOUR-NANGO-INSTANCE>', websocketsPath: '</YOUR-WEBSOCKETS-PATH>' });
+```
+
 ## Telemetry[](#telemetry 'Direct link to Telemetry')
 
 We use telemetry to understand Nango's usage at a high-level and improve it over

--- a/packages/server/lib/controllers/account.controller.ts
+++ b/packages/server/lib/controllers/account.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from 'express';
-import { accountService, errorManager, isCloud, getBaseUrl } from '@nangohq/shared';
+import { accountService, errorManager, isCloud, getBaseUrl, getWebsocketsPath } from '@nangohq/shared';
 import { getOauthCallbackUrl, getUserAndAccountFromSession } from '../utils/utils.js';
 
 class AccountController {
@@ -10,6 +10,7 @@ class AccountController {
             if (!isCloud()) {
                 account.callback_url = await getOauthCallbackUrl();
                 account.secret_key = process.env['NANGO_SECRET_KEY'] || '(none)';
+                account.websockets_path = getWebsocketsPath();
             }
 
             account.host = getBaseUrl();

--- a/packages/server/lib/server.ts
+++ b/packages/server/lib/server.ts
@@ -25,7 +25,7 @@ import passport from 'passport';
 import accountController from './controllers/account.controller.js';
 import type { Response, Request } from 'express';
 import Logger from './utils/logger.js';
-import { accountService, getPort, isCloud, isBasicAuthEnabled, errorManager } from '@nangohq/shared';
+import { accountService, getPort, isCloud, isBasicAuthEnabled, errorManager, getWebsocketsPath } from '@nangohq/shared';
 import oAuthSessionService from './services/oauth-session.service.js';
 import { deleteOldActivityLogs } from './jobs/index.js';
 import migrate from './utils/migrate.js';
@@ -134,7 +134,7 @@ app.get('*', (_, res) => {
 });
 
 const server = http.createServer(app);
-const wsServer = new WebSocketServer({ server });
+const wsServer = new WebSocketServer({ server, path: getWebsocketsPath() });
 
 wsServer.on('connection', (ws: WebSocket) => {
     webSocketClient.addClient(ws);

--- a/packages/shared/lib/models/Admin.ts
+++ b/packages/shared/lib/models/Admin.ts
@@ -9,6 +9,7 @@ export interface Account {
     secret_key_iv?: string | null;
     secret_key_tag?: string | null;
     host?: string | null;
+    websockets_path?: string;
 }
 
 export interface User {

--- a/packages/shared/lib/utils/utils.ts
+++ b/packages/shared/lib/utils/utils.ts
@@ -157,6 +157,16 @@ export function getApiUrl() {
 }
 
 /**
+ * Get any custom path for the websockets server.
+ * Defaults to '/' for backwards compatibility
+ *
+ * @returns the path for the websockets server
+ */
+export function getWebsocketsPath(): string {
+    return process.env['NANGO_SERVER_WEBSOCKETS_PATH'] || '/';
+}
+
+/**
  * A helper function to interpolate a string.
  * interpolateString('Hello ${name} of ${age} years", {name: 'Tester', age: 234}) -> returns 'Hello Tester of age 234 years'
  *

--- a/packages/webapp/src/pages/ConnectionCreate.tsx
+++ b/packages/webapp/src/pages/ConnectionCreate.tsx
@@ -33,6 +33,7 @@ export default function IntegrationCreate() {
     const [selectedScopes, addToScopesSet, removeFromSelectedSet] = useSet<string>();
     const [publicKey, setPublicKey] = useState('');
     const [hostUrl, setHostUrl] = useState('');
+    const [websocketsPath, setWebsocketsPath] = useState('');
     const getIntegrationListAPI = useGetIntegrationListAPI();
     const getProjectInfoAPI = useGetProjectInfoAPI();
     const analyticsTrack = useAnalyticsTrack();
@@ -64,6 +65,7 @@ export default function IntegrationCreate() {
                 const account = (await res.json())['account'];
                 setPublicKey(account.public_key);
                 setHostUrl(account.host || baseUrl());
+                setWebsocketsPath(account.websockets_path); // Undefined is ok, as it's optional.
             }
         };
 
@@ -85,7 +87,7 @@ export default function IntegrationCreate() {
             user_scopes: { value: string };
         };
 
-        const nango = new Nango({ host: hostUrl, publicKey: isCloud() ? publicKey : undefined });
+        const nango = new Nango({ host: hostUrl, websocketsPath: websocketsPath, publicKey: isCloud() ? publicKey : undefined });
 
         nango
             .auth(target.integration_unique_key.value, target.connection_id.value, { user_scope: selectedScopes || [], params: connectionConfigParams || {} })
@@ -140,13 +142,16 @@ export default function IntegrationCreate() {
 
         if (isStaging() || isHosted()) {
             args.push(`host: '${hostUrl}'`);
+            if (websocketsPath && websocketsPath !== '/') {
+                args.push(`websocketsPath: '${websocketsPath}'`);
+            }
         }
 
         if (isCloud() && publicKey) {
             args.push(`publicKey: '${publicKey}'`);
         }
 
-        let argsStr = args.length > 0 ? `{ ${args.join(', ')}}` : '';
+        let argsStr = args.length > 0 ? `{ ${args.join(', ')} }` : '';
 
         let connectionConfigStr = '';
 


### PR DESCRIPTION
# Summary

The websockets path is currently hardcoded to `/` which makes it hard to firewall or otherwise filter requests to the dashboard (which should be very secure) from requests to the websockets (which must be open to non-dashboard users).

This adds:

- `NANGO_SERVER_WEBSOCKETS_PATH` to the server's (optional) environment variables.  This defaults to `/` for backwards compatibility.  If set the websockets server only handles that path (and below).
- `websocketsPath` as an optional config parameter to the frontend `Nango` component. This defaults to `/` for backwards compatibility.
- update to the `/api/v1/account` request to optionally include `websockets_path` in the response (for non-cloud cases).
- update the dashboard to use `websockets_path` from the `/api/v1/account` request to configure the `Nango()` component correctly if a custom path is in use
- Updated `.env.example` with default-off NANGO_SERVER_WEBSOCKETS_PATH example
- Updated documentation for the above

# Testing

Start a server with `NANGO_SERVER_WEBSOCKETS_PATH` _undefined_. Ensure that:

- the server starts
- the dashboard is accessible
- the `Start OAuth Flow` button in _Add New Connection_ correctly triggers a complete OAuth flow (with Xero as the example integration)
- The dev tools show that the websocket connection was made to `/` and worked
- The sample code shown on the same page _doesn't_ include the `websocketsPath` optional config variable.

Start a server with `NANGO_SERVER_WEBSOCKETS_PATH=`/websocket`. Ensure that:

- the server starts
- the dashboard is accessible
- the `Start OAuth Flow` button in _Add New Connection_ correctly triggers a complete OAuth flow (with Xero as the example integration)
- The dev tools show that the websocket connection was made to `/websocket` and worked
- The sample code shown on the same page _does_ include the `websocketsPath: "/websocket"` optional config variable.

Do a docker build (`npm run build:hosted` then `npm run docker-build`), and modify the `docker-compose.yaml` file to use the locally built server image, and test:

- All the above tests work when `NANGO_SERVER_WEBSOCKETS_PATH` is _not_ include in the `environment` specification of the server image
- All the above tests work when `NANGO_SERVER_WEBSOCKETS_PATH=/ws` is set in the `environment` specification of the server image